### PR TITLE
Feature/#3 ERD 기반 Entity 구성

### DIFF
--- a/src/main/java/com/umc/approval/ApprovalApplication.java
+++ b/src/main/java/com/umc/approval/ApprovalApplication.java
@@ -1,8 +1,11 @@
 package com.umc.approval;
 
+import com.umc.approval.global.type.SocialType;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ApprovalApplication {
 

--- a/src/main/java/com/umc/approval/domain/BaseTimeEntity.java
+++ b/src/main/java/com/umc/approval/domain/BaseTimeEntity.java
@@ -23,3 +23,4 @@ public abstract class BaseTimeEntity {
     @Column(name = "modified_at", nullable = false)
     private LocalDateTime modifiedAt;
 }
+

--- a/src/main/java/com/umc/approval/domain/accuse/entity/Accuse.java
+++ b/src/main/java/com/umc/approval/domain/accuse/entity/Accuse.java
@@ -1,0 +1,56 @@
+package com.umc.approval.domain.accuse.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.comment.entity.Comment;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Accuse extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "accuse_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "accuse_user_id")
+    private User accuseUser;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/com/umc/approval/domain/approval/entity/Approval.java
+++ b/src/main/java/com/umc/approval/domain/approval/entity/Approval.java
@@ -1,0 +1,40 @@
+package com.umc.approval.domain.approval.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Approval extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "approval_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @Column(nullable = false)
+    private Boolean isApprove;
+}

--- a/src/main/java/com/umc/approval/domain/category/entity/Category.java
+++ b/src/main/java/com/umc/approval/domain/category/entity/Category.java
@@ -1,0 +1,35 @@
+package com.umc.approval.domain.category.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)  // 관심부서
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String category;
+}

--- a/src/main/java/com/umc/approval/domain/cert/entity/Cert.java
+++ b/src/main/java/com/umc/approval/domain/cert/entity/Cert.java
@@ -1,0 +1,34 @@
+package com.umc.approval.domain.cert.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Cert {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "cert_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String certNumber;
+}

--- a/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
@@ -1,0 +1,56 @@
+package com.umc.approval.domain.comment.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment; // 대댓글
+
+    @Column(nullable = false)
+    private String content; //255자 최대
+
+    private String imageUrl;
+}

--- a/src/main/java/com/umc/approval/domain/document/entity/Document.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/Document.java
@@ -1,0 +1,53 @@
+package com.umc.approval.domain.document.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.category.entity.Category;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Document extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "document_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "longtext", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer state;
+
+    @Column(nullable = false)
+    private Long view;
+
+    @Column(columnDefinition = "tinyint(1) default 1", nullable = false)
+    private Boolean notification;
+}

--- a/src/main/java/com/umc/approval/domain/follow/entity/Follow.java
+++ b/src/main/java/com/umc/approval/domain/follow/entity/Follow.java
@@ -1,0 +1,36 @@
+package com.umc.approval.domain.follow.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Follow extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "from_user_id", nullable = false)
+    private User fromUser;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "to_user_id", nullable = false)
+    private User toUser;
+}

--- a/src/main/java/com/umc/approval/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/approval/domain/image/entity/Image.java
@@ -1,0 +1,45 @@
+package com.umc.approval.domain.image.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @Column(nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/umc/approval/domain/like/entity/Like.java
+++ b/src/main/java/com/umc/approval/domain/like/entity/Like.java
@@ -1,0 +1,53 @@
+package com.umc.approval.domain.like.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.comment.entity.Comment;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "likes")
+public class Like extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/com/umc/approval/domain/link/entity/Link.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/Link.java
@@ -1,0 +1,45 @@
+package com.umc.approval.domain.link.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Link extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "link_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @Column(nullable = false)
+    private String linkUrl;
+}

--- a/src/main/java/com/umc/approval/domain/performance/entity/Performance.java
+++ b/src/main/java/com/umc/approval/domain/performance/entity/Performance.java
@@ -1,0 +1,37 @@
+package com.umc.approval.domain.performance.entity;
+
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Performance {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "performance_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer point;
+}

--- a/src/main/java/com/umc/approval/domain/report/entity/Report.java
+++ b/src/main/java/com/umc/approval/domain/report/entity/Report.java
@@ -1,0 +1,40 @@
+package com.umc.approval.domain.report.entity;
+
+import com.umc.approval.domain.document.entity.Document;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Report {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+    @Column(nullable = false, columnDefinition = "longtext")
+    private String content;
+
+    @Column(nullable = false)
+    private Long view;
+
+    @Column(columnDefinition = "tinyint(1) default 1", nullable = false)
+    private Boolean notification;
+}

--- a/src/main/java/com/umc/approval/domain/scrap/entity/Scrap.java
+++ b/src/main/java/com/umc/approval/domain/scrap/entity/Scrap.java
@@ -1,0 +1,46 @@
+package com.umc.approval.domain.scrap.entity;
+
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Scrap {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "scrap_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+}

--- a/src/main/java/com/umc/approval/domain/tag/entity/Tag.java
+++ b/src/main/java/com/umc/approval/domain/tag/entity/Tag.java
@@ -1,0 +1,44 @@
+package com.umc.approval.domain.tag.entity;
+
+import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.report.entity.Report;
+import com.umc.approval.domain.toktok.entity.Toktok;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "toktok_id")
+    private Toktok toktok;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @Column(nullable = false)
+    private String tag;
+}

--- a/src/main/java/com/umc/approval/domain/toktok/entity/Toktok.java
+++ b/src/main/java/com/umc/approval/domain/toktok/entity/Toktok.java
@@ -1,0 +1,52 @@
+package com.umc.approval.domain.toktok.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.category.entity.Category;
+import com.umc.approval.domain.user.entity.User;
+import com.umc.approval.domain.vote.entity.Vote;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Toktok extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "toktok_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "vote_id")
+    private Vote vote;
+
+    @Column(columnDefinition = "longtext", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Long view;
+
+    @Column(columnDefinition = "tinyint(1) default 1", nullable = false)
+    private boolean notification;
+}

--- a/src/main/java/com/umc/approval/domain/user/entity/User.java
+++ b/src/main/java/com/umc/approval/domain/user/entity/User.java
@@ -1,0 +1,57 @@
+package com.umc.approval.domain.user.entity;
+
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.global.type.SocialType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String profileImage;
+
+    @Enumerated(value = STRING)
+    private SocialType socialType;
+
+    private Long socialId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private Integer level;
+
+    @Column(nullable = false)
+    private Long promotionPoint;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/umc/approval/domain/vote/entity/UserVote.java
+++ b/src/main/java/com/umc/approval/domain/vote/entity/UserVote.java
@@ -1,0 +1,41 @@
+package com.umc.approval.domain.vote.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import com.umc.approval.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "user_vote")
+public class UserVote extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "user_vote_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "vote_option_id", nullable = false)
+    private VoteOption voteOption;
+}

--- a/src/main/java/com/umc/approval/domain/vote/entity/Vote.java
+++ b/src/main/java/com/umc/approval/domain/vote/entity/Vote.java
@@ -1,0 +1,43 @@
+package com.umc.approval.domain.vote.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class Vote extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "vote_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Boolean isSingle;
+
+    @Column(nullable = false)
+    private Boolean isAnonymous;
+
+    @Column(nullable = false)
+    private Boolean isEnd;
+
+}

--- a/src/main/java/com/umc/approval/domain/vote/entity/VoteOption.java
+++ b/src/main/java/com/umc/approval/domain/vote/entity/VoteOption.java
@@ -1,0 +1,35 @@
+package com.umc.approval.domain.vote.entity;
+
+import com.umc.approval.domain.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "vote_option")
+public class VoteOption extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "vote_option_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @Column(nullable = false)
+    private String option;
+}

--- a/src/main/java/com/umc/approval/domain/vote/entity/VoteOption.java
+++ b/src/main/java/com/umc/approval/domain/vote/entity/VoteOption.java
@@ -31,5 +31,5 @@ public class VoteOption extends BaseTimeEntity {
     private Vote vote;
 
     @Column(nullable = false)
-    private String option;
+    private String opt;
 }

--- a/src/main/java/com/umc/approval/global/type/SocialType.java
+++ b/src/main/java/com/umc/approval/global/type/SocialType.java
@@ -1,0 +1,5 @@
+package com.umc.approval.global.type;
+
+public enum SocialType {
+    KAKAO, GOOGLE, NAVER
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 # DB
 spring:
+  profiles:
+    include: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/approval?characterEncoding=UTF-8&serverTimezone=UTC


### PR DESCRIPTION
## 📝 PR 내용
설계한 ERD를 기반으로 Entity 구성
- 샤피 : Accuse, Approval, Category, Comment
- 벨 : Document, Follow, Image, Like
- 빠쿤 : Tag, Scrap, Cert, Link, Performance, Report, Tag
- 테사 : Toktok, User, Vote(Vote, UserVote, VoteOption)

정상적으로 Table 생성됨을 확인 !

## 관련 이슈
close #3 