### PR TITLE
Feature/#21 결재하기 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/umc/approval/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/umc/approval/domain/document/controller/DocumentController.java
@@ -5,10 +5,7 @@ import com.umc.approval.domain.document.service.DocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
@@ -26,6 +23,12 @@ public class DocumentController {
     public ResponseEntity<Void> createDocument(@Valid @RequestPart(value = "data", required = false) DocumentDto.PostDocumentRequest request,
                                                @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         documentService.createDocument(request, images);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{documentId}")
+    public ResponseEntity<Void> deleteDocument(@PathVariable("documentId") Long documentId){
+        documentService.deleteDocument(documentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
+++ b/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
@@ -24,6 +24,6 @@ public class DocumentDto {
         private String content;
 
         private List<String> tag;
-        private List<String> linkUrl;
+        private String linkUrl;
     }
 }

--- a/src/main/java/com/umc/approval/domain/document/entity/Document.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/Document.java
@@ -54,6 +54,6 @@ public class Document extends BaseTimeEntity {
     @Column(columnDefinition = "tinyint(1) default 1", nullable = false)
     private Boolean notification;
 
-    @Column
+    @Column(name = "link_url")
     private String linkUrl;
 }

--- a/src/main/java/com/umc/approval/domain/document/entity/Document.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/Document.java
@@ -53,4 +53,7 @@ public class Document extends BaseTimeEntity {
 
     @Column(columnDefinition = "tinyint(1) default 1", nullable = false)
     private Boolean notification;
+
+    @Column
+    private String linkUrl;
 }

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -93,16 +93,28 @@ public class DocumentService {
         findDocument(documentId);
 
         // tag 삭제
-        tagRepository.deleteByDocumentId(documentId);
+        List<Tag> tagList = tagRepository.findByDocumentId(documentId);
+        if(tagList != null){
+            for(Tag tag: tagList){
+                tagRepository.deleteById(tag.getId());
+            }
+        }
 
         // link 삭제
-        linkRepository.deleteByDocumentId(documentId);
+        List<Link> linkList = linkRepository.findByDocumentId(documentId);
+        if(linkList != null){
+            for(Link link: linkList){
+                linkRepository.deleteById(link.getId());
+            }
+        }
 
         // image 삭제
-        List<String> imageUrlList = imageRepository.findImageUrl(documentId);
-        imageRepository.deleteByDocumentId(documentId);
-        for(String path: imageUrlList){
-            awsS3Service.deleteImage(path);
+        List<Image> imageList = imageRepository.findByDocumentId(documentId);
+        if(imageList != null){
+            imageRepository.deleteByDocumentId(documentId);
+            for(Image image: imageList){
+                awsS3Service.deleteImage(image.getImageUrl());
+            }
         }
 
         // document 삭제
@@ -110,7 +122,6 @@ public class DocumentService {
     }
 
 
-    // 사용자 인증
     private User certifyUser(){
         User user = userRepository.findById(jwtService.getId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.umc.approval.global.exception.CustomErrorType.DOCUMENT_NOT_FOUND;
 import static com.umc.approval.global.exception.CustomErrorType.USER_NOT_FOUND;
 
 @Transactional
@@ -89,6 +90,8 @@ public class DocumentService {
 
     public void deleteDocument(Long documentId) {
 
+        findDocument(documentId);
+
         // tag 삭제
         tagRepository.deleteByDocumentId(documentId);
 
@@ -112,5 +115,12 @@ public class DocumentService {
         User user = userRepository.findById(jwtService.getId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         return user;
+    }
+
+    private void findDocument(Long documentId){
+        Optional<Document> document = documentRepository.findById(documentId);
+        if(document.isEmpty()){
+            throw new CustomException(DOCUMENT_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -58,6 +58,7 @@ public class DocumentService {
                 .state(2) //승인대기중
                 .view(0L)
                 .notification(true)
+                .linkUrl(request.getLinkUrl())
                 .build();
         documentRepository.save(document);
 
@@ -65,11 +66,6 @@ public class DocumentService {
             for (String tag : request.getTag()) {
                 Tag newTag = Tag.builder().document(document).tag(tag).build();
                 tagRepository.save(newTag);
-            }
-        if (request.getLinkUrl() != null)
-            for (String link : request.getLinkUrl()) {
-                Link newLink = Link.builder().document(document).linkUrl(link).build();
-                linkRepository.save(newLink);
             }
         if (images != null) {
             if (images.size() == 1) {
@@ -100,14 +96,6 @@ public class DocumentService {
         if(tagList != null){
             for(Tag tag: tagList){
                 tagRepository.deleteById(tag.getId());
-            }
-        }
-
-        // link 삭제
-        List<Link> linkList = linkRepository.findByDocumentId(documentId);
-        if(linkList != null){
-            for(Link link: linkList){
-                linkRepository.deleteById(link.getId());
             }
         }
 

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -90,7 +90,8 @@ public class DocumentService {
     public void deleteDocument(Long documentId) {
         // 게시글 존재 유무, 삭제 권한 확인
         Document document = findDocument(documentId);
-        if(jwtService.getId() != document.getUser().getId()){
+        User user = certifyUser();
+        if(user.getId() != document.getUser().getId()){
             throw new CustomException(NO_PERMISSION);
         }
 

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -26,8 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.umc.approval.global.exception.CustomErrorType.DOCUMENT_NOT_FOUND;
-import static com.umc.approval.global.exception.CustomErrorType.USER_NOT_FOUND;
+import static com.umc.approval.global.exception.CustomErrorType.*;
 
 @Transactional
 @RequiredArgsConstructor
@@ -89,8 +88,11 @@ public class DocumentService {
 
 
     public void deleteDocument(Long documentId) {
-
-        findDocument(documentId);
+        // 게시글 존재 유무, 삭제 권한 확인
+        Document document = findDocument(documentId);
+        if(jwtService.getId() != document.getUser().getId()){
+            throw new CustomException(NO_PERMISSION);
+        }
 
         // tag 삭제
         List<Tag> tagList = tagRepository.findByDocumentId(documentId);
@@ -128,10 +130,11 @@ public class DocumentService {
         return user;
     }
 
-    private void findDocument(Long documentId){
+    private Document findDocument(Long documentId){
         Optional<Document> document = documentRepository.findById(documentId);
         if(document.isEmpty()){
             throw new CustomException(DOCUMENT_NOT_FOUND);
         }
+        return document.get();
     }
 }

--- a/src/main/java/com/umc/approval/domain/image/entity/ImageRepository.java
+++ b/src/main/java/com/umc/approval/domain/image/entity/ImageRepository.java
@@ -1,6 +1,19 @@
 package com.umc.approval.domain.image.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.transaction.Transactional;
+import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    @Query(value = "select image_url from image where document_id = :document_id", nativeQuery = true)
+    List<String> findImageUrl(@Param("document_id") Long documentId);
+
+    @Modifying
+    @Query(value = "delete from image where document_id = :document_id", nativeQuery = true)
+    void deleteByDocumentId(@Param("document_id") Long documentId);
 
 }

--- a/src/main/java/com/umc/approval/domain/image/entity/ImageRepository.java
+++ b/src/main/java/com/umc/approval/domain/image/entity/ImageRepository.java
@@ -9,11 +9,10 @@ import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    @Query(value = "select image_url from image where document_id = :document_id", nativeQuery = true)
-    List<String> findImageUrl(@Param("document_id") Long documentId);
-
     @Modifying
     @Query(value = "delete from image where document_id = :document_id", nativeQuery = true)
     void deleteByDocumentId(@Param("document_id") Long documentId);
+
+    List<Image> findByDocumentId(Long documentId);
 
 }

--- a/src/main/java/com/umc/approval/domain/link/entity/Link.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/Link.java
@@ -29,10 +29,6 @@ public class Link extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "document_id")
-    private Document document;
-
-    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "toktok_id")
     private Toktok toktok;
 

--- a/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
@@ -8,4 +8,8 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
     @Modifying
     @Query(value = "delete from link where document_id =: document_id", nativeQuery = true)
     void deleteByDocumentId(@Param("document_id") Long documentId);
+
 }
+
+
+

--- a/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
@@ -1,5 +1,11 @@
 package com.umc.approval.domain.link.entity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LinkRepository extends JpaRepository<Link, Long> {
+    @Modifying
+    @Query(value = "delete from link where document_id =: document_id", nativeQuery = true)
+    void deleteByDocumentId(@Param("document_id") Long documentId);
 }

--- a/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
@@ -1,14 +1,8 @@
 package com.umc.approval.domain.link.entity;
-import com.umc.approval.domain.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface LinkRepository extends JpaRepository<Link, Long> {
-    List<Link> findByDocumentId(Long documentId);
 
 }
 

--- a/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
+++ b/src/main/java/com/umc/approval/domain/link/entity/LinkRepository.java
@@ -1,13 +1,14 @@
 package com.umc.approval.domain.link.entity;
+import com.umc.approval.domain.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface LinkRepository extends JpaRepository<Link, Long> {
-    @Modifying
-    @Query(value = "delete from link where document_id =: document_id", nativeQuery = true)
-    void deleteByDocumentId(@Param("document_id") Long documentId);
+    List<Link> findByDocumentId(Long documentId);
 
 }
 

--- a/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
+++ b/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
@@ -5,9 +5,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    @Modifying
-    @Query(value = "delete from tag where document_id = :document_id", nativeQuery = true)
-    void deleteByDocumentId(@Param("document_id") Long documentId);
+    List<Tag> findByDocumentId(Long documentId);
 
 }

--- a/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
+++ b/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
@@ -1,7 +1,13 @@
 package com.umc.approval.domain.tag.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    @Modifying
+    @Query(value = "delete from tag where document_id = :document_id", nativeQuery = true)
+    void deleteByDocumentId(@Param("document_id") Long documentId);
 }

--- a/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
+++ b/src/main/java/com/umc/approval/domain/tag/entity/TagRepository.java
@@ -4,10 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     @Modifying
     @Query(value = "delete from tag where document_id = :document_id", nativeQuery = true)
     void deleteByDocumentId(@Param("document_id") Long documentId);
+
 }

--- a/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
+++ b/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
@@ -22,6 +22,7 @@ public enum CustomErrorType {
     PHONE_NUMBER_ALREADY_EXIST(BAD_REQUEST, 20002, "이미 존재하는 전화번호입니다."),
     LOGIN_FAILED(UNAUTHORIZED, 20003, "아이디 또는 비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(NOT_FOUND, 20004, "사용자를 찾을 수 없습니다."),
+    NO_PERMISSION(FORBIDDEN, 20005, "게시글 수정 및 삭제에 대한 권한이 없습니다."),
 
     DOCUMENT_NOT_FOUND(NOT_FOUND, 30001, "존재하지 않는 결재서류입니다."),
 

--- a/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
+++ b/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
@@ -24,6 +24,7 @@ public enum CustomErrorType {
     USER_NOT_FOUND(NOT_FOUND, 20004, "사용자를 찾을 수 없습니다."),
     NO_PERMISSION(FORBIDDEN, 20005, "게시글 수정 및 삭제에 대한 권한이 없습니다."),
 
+    // Document (3xxxx)
     DOCUMENT_NOT_FOUND(NOT_FOUND, 30001, "존재하지 않는 결재서류입니다."),
 
 

--- a/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
+++ b/src/main/java/com/umc/approval/global/exception/CustomErrorType.java
@@ -23,6 +23,8 @@ public enum CustomErrorType {
     LOGIN_FAILED(UNAUTHORIZED, 20003, "아이디 또는 비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(NOT_FOUND, 20004, "사용자를 찾을 수 없습니다."),
 
+    DOCUMENT_NOT_FOUND(NOT_FOUND, 30001, "존재하지 않는 결재서류입니다."),
+
 
     // Image (8xxxx)
     IMAGE_UPLOAD_FAILED(BAD_REQUEST, 80001, "이미지 업로드에 실패했습니다."),

--- a/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
@@ -41,8 +41,8 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
         return !(
                 // TODO 인증이 필요한 로직 추가
                 pathMatcher.match("/auth/logout", path)
-                        || pathMatcher.match("/documents", path) && request.getMethod().equals("POST")
-                        || pathMatcher.match("/documents/{documentId}", path) && request.getMethod().equals("DELETE")
+                        || pathMatcher.match("/documents/**", path) && request.getMethod().equals("POST")
+                        || pathMatcher.match("/documents/**", path) && request.getMethod().equals("DELETE")
                         || (pathMatcher.match("/community/toktoks", path) && request.getMethod().equals("POST"))
         );
     }

--- a/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
@@ -40,8 +40,10 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
         AntPathMatcher pathMatcher = new AntPathMatcher();
         return !(
                 // TODO 인증이 필요한 로직 추가
-                pathMatcher.match("/auth/logout", path) || pathMatcher.match("/documents", path) && request.getMethod().equals("POST") ||
-                (pathMatcher.match("/community/toktoks", path) && request.getMethod().equals("POST"))
+                pathMatcher.match("/auth/logout", path)
+                        || pathMatcher.match("/documents", path) && request.getMethod().equals("POST")
+                        || pathMatcher.match("/documents/{documentId}", path) && request.getMethod().equals("DELETE")
+                        || (pathMatcher.match("/community/toktoks", path) && request.getMethod().equals("POST"))
         );
     }
 


### PR DESCRIPTION
## 📝 PR 내용
- 결재하기 게시글 삭제 기능 구현
- 결재서류 등록 시 링크 개수 제한(1개)에 따른 entity 수정(Link, Document) 및 기존 게시글 등록 코드 일부 수정

## 관련 이슈
close #21