### PR TITLE
Feature/#57 댓글 목록 조회 구현

### DIFF
--- a/src/main/java/com/umc/approval/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/umc/approval/domain/comment/controller/CommentController.java
@@ -3,10 +3,13 @@ package com.umc.approval.domain.comment.controller;
 import com.umc.approval.domain.comment.dto.CommentDto;
 import com.umc.approval.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
 
@@ -16,6 +19,16 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
+
+
+    @GetMapping
+    public ResponseEntity<CommentDto.ListResponse> getCommentList(
+            HttpServletRequest request,
+            @PageableDefault(size = 20) Pageable pageable,
+            @RequestBody CommentDto.Request requestDto
+    ) {
+        return ResponseEntity.ok(commentService.getCommentList(request, pageable, requestDto));
+    }
 
     @PostMapping
     public ResponseEntity<Void> createComment(

--- a/src/main/java/com/umc/approval/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/umc/approval/domain/comment/dto/CommentDto.java
@@ -7,11 +7,13 @@ import com.umc.approval.domain.like.entity.Like;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.toktok.entity.Toktok;
 import com.umc.approval.domain.user.entity.User;
+import com.umc.approval.global.util.DateUtil;
 import lombok.*;
 import org.springframework.data.domain.Page;
 
 import javax.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommentDto {
 
@@ -58,14 +60,19 @@ public class CommentDto {
     public static class ListResponse {
         private Integer page;
         private Integer totalPage;
-        private Long totalElement;
+        private Integer totalCommentCount;
         private List<ParentResponse> content;
 
-        public static LikeDto.ListResponse from(Page<Like> page, List<LikeDto.Response> content) {
-            return LikeDto.ListResponse.builder()
-                    .page(page.getNumber())
-                    .totalPage(page.getTotalPages())
-                    .totalElement(page.getTotalElements())
+        public static ListResponse from(
+                Page<Comment> comments, Integer commentCount, Long userId, Long writerId, List<Like> likes
+        ) {
+            List<ParentResponse> content = comments.getContent().stream()
+                    .map(c -> ParentResponse.from(c, userId, writerId, likes))
+                    .collect(Collectors.toList());
+            return ListResponse.builder()
+                    .page(comments.getNumber())
+                    .totalPage(comments.getTotalPages())
+                    .totalCommentCount(commentCount)
                     .content(content)
                     .build();
         }
@@ -81,6 +88,7 @@ public class CommentDto {
         private String nickname;
         private Integer level;
         private String content;
+        private String imageUrl;
         private List<ChildResponse> childComment;
         private Boolean isWriter;
         private Boolean isMy;
@@ -88,6 +96,28 @@ public class CommentDto {
         private Boolean isDeleted;
         private Integer likeCount;
         private String datetime;
+
+        public static ParentResponse from(Comment comment, Long userId, Long writerId, List<Like> likes) {
+            List<ChildResponse> childComment = comment.getChildComment().stream()
+                    .map(c -> ChildResponse.from(c, userId, writerId, likes))
+                    .collect(Collectors.toList());
+            return ParentResponse.builder()
+                    .commentId(comment.getId())
+                    .userId(comment.getUser().getId())
+                    .profileImage(comment.getUser().getProfileImage())
+                    .nickname(comment.getUser().getNickname())
+                    .level(comment.getUser().getLevel())
+                    .content(comment.getContent())
+                    .imageUrl(comment.getImageUrl())
+                    .childComment(childComment)
+                    .isWriter(writerId.equals(comment.getUser().getId()))
+                    .isMy(userId != null && userId.equals(comment.getUser().getId()))
+                    .isLike(likes.stream().anyMatch(l -> l.getComment().getId() == comment.getId()))
+                    .isDeleted(comment.getIsDeleted())
+                    .likeCount(comment.getLikes().size())
+                    .datetime(DateUtil.convert(comment.getCreatedAt()))
+                    .build();
+        }
     }
 
     @Getter
@@ -100,11 +130,29 @@ public class CommentDto {
         private String nickname;
         private Integer level;
         private String content;
+        private String imageUrl;
         private Boolean isWriter;
         private Boolean isMy;
         private Boolean isLike;
         private Integer likeCount;
         private String datetime;
+
+        public static ChildResponse from(Comment comment, Long userId, Long writerId, List<Like> likes) {
+            return ChildResponse.builder()
+                    .commentId(comment.getId())
+                    .userId(comment.getUser().getId())
+                    .profileImage(comment.getUser().getProfileImage())
+                    .nickname(comment.getUser().getNickname())
+                    .level(comment.getUser().getLevel())
+                    .content(comment.getContent())
+                    .imageUrl(comment.getImageUrl())
+                    .isWriter(writerId.equals(comment.getUser().getId()))
+                    .isMy(userId != null && userId.equals(comment.getUser().getId()))
+                    .isLike(likes.stream().anyMatch(l -> l.getComment().getId() == comment.getId()))
+                    .likeCount(comment.getLikes().size())
+                    .datetime(DateUtil.convert(comment.getCreatedAt()))
+                    .build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/umc/approval/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/umc/approval/domain/comment/dto/CommentDto.java
@@ -2,14 +2,27 @@ package com.umc.approval.domain.comment.dto;
 
 import com.umc.approval.domain.comment.entity.Comment;
 import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.like.dto.LikeDto;
+import com.umc.approval.domain.like.entity.Like;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.toktok.entity.Toktok;
 import com.umc.approval.domain.user.entity.User;
 import lombok.*;
+import org.springframework.data.domain.Page;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 public class CommentDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Request {
+        private Long documentId;
+        private Long toktokId;
+        private Long reportId;
+    }
 
     @Getter
     @Builder
@@ -37,6 +50,61 @@ public class CommentDto {
                     .imageUrl(imageUrl)
                     .build();
         }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ListResponse {
+        private Integer page;
+        private Integer totalPage;
+        private Long totalElement;
+        private List<ParentResponse> content;
+
+        public static LikeDto.ListResponse from(Page<Like> page, List<LikeDto.Response> content) {
+            return LikeDto.ListResponse.builder()
+                    .page(page.getNumber())
+                    .totalPage(page.getTotalPages())
+                    .totalElement(page.getTotalElements())
+                    .content(content)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ParentResponse {
+        private Long commentId;
+        private Long userId;
+        private String profileImage;
+        private String nickname;
+        private Integer level;
+        private String content;
+        private List<ChildResponse> childComment;
+        private Boolean isWriter;
+        private Boolean isMy;
+        private Boolean isLike;
+        private Boolean isDeleted;
+        private Integer likeCount;
+        private String datetime;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ChildResponse {
+        private Long commentId;
+        private Long userId;
+        private String profileImage;
+        private String nickname;
+        private Integer level;
+        private String content;
+        private Boolean isWriter;
+        private Boolean isMy;
+        private Boolean isLike;
+        private Integer likeCount;
+        private String datetime;
     }
 
     @Getter

--- a/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import java.util.List;
+
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PRIVATE;
@@ -48,6 +50,9 @@ public class Comment extends BaseTimeEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment; // 대댓글
+
+    @OneToMany(mappedBy = "parentComment")
+    private List<Comment> childComment;
 
     @Column(nullable = false)
     private String content; //255자 최대

--- a/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.umc.approval.domain.comment.entity;
 
 import com.umc.approval.domain.BaseTimeEntity;
 import com.umc.approval.domain.document.entity.Document;
+import com.umc.approval.domain.like.entity.Like;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.toktok.entity.Toktok;
 import com.umc.approval.domain.user.entity.User;
@@ -11,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-
 import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
@@ -53,6 +53,9 @@ public class Comment extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "parentComment")
     private List<Comment> childComment;
+
+    @OneToMany(mappedBy = "comment")
+    private List<Like> likes;
 
     @Column(nullable = false)
     private String content; //255자 최대

--- a/src/main/java/com/umc/approval/domain/comment/entity/CommentRepository.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
     @Query("select c from Comment c " +
             "join fetch c.user u " +

--- a/src/main/java/com/umc/approval/domain/comment/entity/CommentRepositoryCustom.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/CommentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.umc.approval.domain.comment.entity;
+
+import com.umc.approval.domain.comment.dto.CommentDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepositoryCustom {
+    Page<Comment> findAllByPost(Pageable pageable, CommentDto.Request requestDto);
+
+    Integer countByPost(CommentDto.Request requestDto);
+}

--- a/src/main/java/com/umc/approval/domain/comment/entity/CommentRepositoryImpl.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/CommentRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.umc.approval.domain.comment.entity;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.approval.domain.comment.dto.CommentDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.umc.approval.domain.comment.entity.QComment.comment;
+
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    public CommentRepositoryImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Comment> findAllByPost(Pageable pageable, CommentDto.Request requestDto) {
+
+        QComment cc = new QComment("cc");
+
+        List<Comment> comments = queryFactory
+                .selectFrom(comment)
+                .leftJoin(comment.childComment, cc) // 대댓글 함께 조회
+                .leftJoin(cc.user) // 대댓글 유저 함께 조회
+                .leftJoin(cc.likes) // 대댓글 좋아요 함께 조회
+                .innerJoin(comment.user) // 댓글 유저 함께 조회
+                .leftJoin(comment.likes) // 댓글 좋아요 함께 조회
+                .where(
+                        documentEq(requestDto.getDocumentId()),
+                        toktokEq(requestDto.getToktokId()),
+                        reportEq(requestDto.getReportId()),
+                        comment.parentComment.id.isNull() // 대댓글이 아닌 것만
+                )
+                .distinct()
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(
+                        documentEq(requestDto.getDocumentId()),
+                        toktokEq(requestDto.getToktokId()),
+                        reportEq(requestDto.getReportId()),
+                        comment.parentComment.id.isNull()
+                );
+
+        return PageableExecutionUtils.getPage(comments, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Integer countByPost(CommentDto.Request requestDto) {
+        return Math.toIntExact(queryFactory
+                .select(comment.count())
+                .where(
+                        documentEq(requestDto.getDocumentId()),
+                        toktokEq(requestDto.getToktokId()),
+                        reportEq(requestDto.getReportId())
+                )
+                .from(comment)
+                .fetchFirst());
+    }
+
+    private BooleanExpression documentEq(Long documentId) {
+        return documentId == null ? null : comment.document.id.eq(documentId);
+    }
+
+    private BooleanExpression toktokEq(Long toktokId) {
+        return toktokId == null ? null : comment.toktok.id.eq(toktokId);
+    }
+
+    private BooleanExpression reportEq(Long reportId) {
+        return reportId == null ? null : comment.report.id.eq(reportId);
+    }
+}

--- a/src/main/java/com/umc/approval/domain/comment/service/CommentService.java
+++ b/src/main/java/com/umc/approval/domain/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import com.umc.approval.domain.comment.entity.Comment;
 import com.umc.approval.domain.comment.entity.CommentRepository;
 import com.umc.approval.domain.document.entity.Document;
 import com.umc.approval.domain.document.entity.DocumentRepository;
+import com.umc.approval.domain.like.entity.Like;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.report.entity.ReportRepository;
 import com.umc.approval.domain.toktok.entity.Toktok;
@@ -15,10 +16,13 @@ import com.umc.approval.global.aws.service.AwsS3Service;
 import com.umc.approval.global.exception.CustomException;
 import com.umc.approval.global.security.service.JwtService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 import static com.umc.approval.global.exception.CustomErrorType.*;
@@ -130,5 +134,11 @@ public class CommentService {
     private User getUser() {
         return userRepository.findById(jwtService.getId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    public CommentDto.ListResponse getCommentList(HttpServletRequest request, Pageable pageable, CommentDto.Request requestDto) {
+
+        Page<Comment> comments = commentRepository.findAllByPost(pageable, requestDto);
+        return null;
     }
 }

--- a/src/main/java/com/umc/approval/domain/comment/service/CommentService.java
+++ b/src/main/java/com/umc/approval/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.umc.approval.domain.comment.entity.CommentRepository;
 import com.umc.approval.domain.document.entity.Document;
 import com.umc.approval.domain.document.entity.DocumentRepository;
 import com.umc.approval.domain.like.entity.Like;
+import com.umc.approval.domain.like.entity.LikeRepository;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.report.entity.ReportRepository;
 import com.umc.approval.domain.toktok.entity.Toktok;
@@ -23,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.umc.approval.global.exception.CustomErrorType.*;
 
@@ -39,6 +42,7 @@ public class CommentService {
     private final DocumentRepository documentRepository;
     private final ReportRepository reportRepository;
     private final ToktokRepository toktokRepository;
+    private final LikeRepository likeRepository;
 
     public void createComment(CommentDto.CreateRequest requestDto, List<MultipartFile> images) {
 
@@ -139,6 +143,33 @@ public class CommentService {
     public CommentDto.ListResponse getCommentList(HttpServletRequest request, Pageable pageable, CommentDto.Request requestDto) {
 
         Page<Comment> comments = commentRepository.findAllByPost(pageable, requestDto);
-        return null;
+        Integer commentCount = commentRepository.countByPost(requestDto);
+
+        // 글쓴이 조회
+        User writer;
+        if (requestDto.getDocumentId() != null) {
+            Document document = documentRepository.findByIdWithUser(requestDto.getDocumentId())
+                    .orElseThrow(() -> new CustomException(DOCUMENT_NOT_FOUND));
+            writer = document.getUser();
+        } else if (requestDto.getReportId() != null) {
+            Report report = reportRepository.findByIdWithUser(requestDto.getReportId())
+                    .orElseThrow(() -> new CustomException(REPORT_NOT_FOUND));
+            writer = report.getDocument().getUser();
+        } else {
+            Toktok toktok = toktokRepository.findByIdWithUser(requestDto.getToktokId())
+                    .orElseThrow(() -> new CustomException(TOKTOKPOST_NOT_FOUND));
+            writer = toktok.getUser();
+        }
+
+        // (로그인 시) 사용자가 좋아요 누른 댓글 리스트 조회
+        Long userId = jwtService.getIdDirectHeader(request);
+        List<Comment> allComments = new ArrayList<>(comments.getContent());
+        comments.getContent().forEach(c -> {
+            if (c.getChildComment() != null) allComments.addAll(c.getChildComment());
+        });
+        List<Long> commentIds = allComments.stream().map(Comment::getId).collect(Collectors.toList());
+        List<Like> likes = likeRepository.findAllByUserAndCommentIn(userId, commentIds);
+
+        return CommentDto.ListResponse.from(comments, commentCount, userId, writer.getId(), likes);
     }
 }

--- a/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
+++ b/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
@@ -3,14 +3,13 @@ package com.umc.approval.domain.document.dto;
 import com.umc.approval.domain.document.entity.Document;
 import com.umc.approval.domain.user.entity.User;
 import com.umc.approval.global.type.CategoryType;
-import lombok.Builder;
+import com.umc.approval.global.util.DateUtil;
 import lombok.Data;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.xml.datatype.DatatypeConstants;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -70,7 +69,7 @@ public class DocumentDto {
         // etc..
         private Integer likedCount;
         private Integer commentCount;
-        private String createdAt;
+        private String datetime;
         private Long view;
 
 
@@ -94,7 +93,7 @@ public class DocumentDto {
 
             this.likedCount = likedCount;
             this.commentCount = commentCount;
-            this.createdAt = document.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
+            this.datetime = DateUtil.convert(document.getCreatedAt());
             this.view = document.getView();
         }
     }

--- a/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
@@ -5,10 +5,16 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 
     @Modifying
     @Query(value = "update document set view = view + 1 where document_id = :document_id", nativeQuery = true)
     void updateView(@Param("document_id") Long document_id);
 
+    @Query("select d from Document d " +
+            "join fetch d.user u " +
+            "where d.id = :documentId")
+    Optional<Document> findByIdWithUser(Long documentId);
 }

--- a/src/main/java/com/umc/approval/domain/like/dto/LikeDto.java
+++ b/src/main/java/com/umc/approval/domain/like/dto/LikeDto.java
@@ -2,7 +2,10 @@ package com.umc.approval.domain.like.dto;
 
 import com.umc.approval.domain.like.entity.Like;
 import com.umc.approval.domain.user.entity.User;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;

--- a/src/main/java/com/umc/approval/domain/like/entity/LikeRepository.java
+++ b/src/main/java/com/umc/approval/domain/like/entity/LikeRepository.java
@@ -4,8 +4,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface LikeRepository extends JpaRepository<Like, Long>, LikeRepositoryCustom {
 
     @Query(value = "select count(*) from likes where document_id = :document_id", nativeQuery = true)
     int countByDocumentId(@Param("document_id") Long documentId);
+
+    @Query("select l from Like l " +
+            "join fetch l.comment c " +
+            "where l.user.id = :userId " +
+            "and l.comment.id in :commentIds")
+    List<Like> findAllByUserAndCommentIn(Long userId, List<Long> commentIds);
 }

--- a/src/main/java/com/umc/approval/domain/report/entity/ReportRepository.java
+++ b/src/main/java/com/umc/approval/domain/report/entity/ReportRepository.java
@@ -1,9 +1,18 @@
 package com.umc.approval.domain.report.entity;
 
 import com.umc.approval.domain.document.entity.Document;
+
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
     Optional<Report> findByDocumentId(Long documentId);
+
+    @Query("select r from Report r " +
+            "join fetch r.document d " +
+            "join fetch d.user u " +
+            "where r.id = :reportId")
+    Optional<Report> findByIdWithUser(Long reportId);
 }

--- a/src/main/java/com/umc/approval/domain/toktok/entity/ToktokRepository.java
+++ b/src/main/java/com/umc/approval/domain/toktok/entity/ToktokRepository.java
@@ -1,8 +1,15 @@
 package com.umc.approval.domain.toktok.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 public interface ToktokRepository extends JpaRepository<Toktok, Long> {
 
+    @Query("select t from Toktok t " +
+            "join fetch t.user u " +
+            "where t.id = :toktokId")
+    Optional<Toktok> findByIdWithUser(Long toktokId);
 }

--- a/src/main/java/com/umc/approval/global/util/DateUtil.java
+++ b/src/main/java/com/umc/approval/global/util/DateUtil.java
@@ -1,0 +1,35 @@
+package com.umc.approval.global.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+    public static final int SEC = 60;
+    public static final int MIN = 60;
+    public static final int HOUR = 24;
+
+    public static String convert(LocalDateTime date) {
+        LocalDateTime now = LocalDateTime.now();
+        long curTime = now.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
+        long regTime = date.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli();
+        long diffTime = (curTime - regTime) / 1000;
+
+        // 작성일이 지났을 때
+        if (!now.toLocalDate().isEqual(date.toLocalDate())) {
+            return DateTimeFormatter.ofPattern("yy/MM/dd HH:mm").format(date);
+        }
+
+        String msg = null;
+
+        if (diffTime < SEC) {
+            msg = "1분 전";
+        } else if ((diffTime /= SEC) < MIN) {
+            msg = diffTime + "분 전";
+        } else if ((diffTime /= MIN) < HOUR) {
+            msg = diffTime + "시간 전";
+        }
+
+        return msg;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL57Dialect
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 100
 
 # AWS
 cloud:


### PR DESCRIPTION
## 📝 PR 내용
댓글 목록 조회 구현
- QueryDSL 사용 동적쿼리 댓글 조회 구현
- 결재서류 상세조회 - 날짜포맷 메서드 사용 변경

## 관련 이슈
close #57 