### PR TITLE
[FIX #64] 코드 충돌로 인한 빌드 실패 수정

### DIFF
--- a/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
+++ b/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
@@ -69,7 +69,6 @@ public class DocumentDto {
         // etc..
         private Integer likedCount;
         private Integer commentCount;
-        private String updatedAt;
         private String datetime;
         private Long view;
 
@@ -94,7 +93,6 @@ public class DocumentDto {
 
             this.likedCount = likedCount;
             this.commentCount = commentCount;
-            this.updatedAt = document.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
             this.datetime = DateUtil.convert(document.getCreatedAt());
             this.view = document.getView();
         }
@@ -116,7 +114,7 @@ public class DocumentDto {
         private Integer rejectCount;
 
         // etc..
-        private String updatedAt;
+        private String datetime;
         private Long view;
 
         // Entity -> DTO
@@ -132,7 +130,7 @@ public class DocumentDto {
             this.approveCount = approveCount;
             this.rejectCount = rejectCount;
 
-            this.updatedAt = document.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm"));
+            this.datetime = DateUtil.convert(document.getCreatedAt());
             this.view = document.getView();
         }
     }

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -84,8 +84,8 @@ public class DocumentService {
         int likedCount = likeRepository.countByDocumentId(documentId);
         int commentCount = commentRepository.countByDocumentId(documentId);
 
-        return new DocumentDto.DocumentResponse(document, user, tagNameList, imageUrlList,
-                approvalCount, rejectCount, likedCount, commentCount);
+        return new DocumentDto.GetDocumentResponse(document, user, tagNameList, imageUrlList,
+                approveCount, rejectCount, likedCount, commentCount);
     }
 
     public void updateDocument(Long documentId, DocumentDto.DocumentRequest request, List<MultipartFile> images) {

--- a/src/main/java/com/umc/approval/domain/follow/entity/FollowRepository.java
+++ b/src/main/java/com/umc/approval/domain/follow/entity/FollowRepository.java
@@ -12,4 +12,12 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
             "where f.fromUser.id = :fromUserId " +
             "and f.toUser.id in :toUserIds")
     List<Follow> findAllByToUserIn(Long fromUserId, List<Long> toUserIds);
+
+    @Query("select count(f) from Follow f " +
+            "where f.fromUser.id = :userId")
+    Integer countByFromUser(Long userId);
+
+    @Query("select count(f) from Follow f " +
+            "where f.toUser.id = :userId")
+    Integer countByToUser(Long userId);
 }

--- a/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
@@ -4,6 +4,7 @@ import com.umc.approval.domain.approval.entity.ApprovalRepository;
 import com.umc.approval.domain.document.dto.DocumentDto;
 import com.umc.approval.domain.document.entity.Document;
 import com.umc.approval.domain.document.entity.DocumentRepository;
+import com.umc.approval.domain.follow.entity.FollowRepository;
 import com.umc.approval.domain.image.entity.ImageRepository;
 import com.umc.approval.domain.tag.entity.TagRepository;
 import com.umc.approval.domain.user.entity.User;
@@ -32,6 +33,7 @@ public class ProfileService {
     private final TagRepository tagRepository;
     private final ImageRepository imageRepository;
     private final ApprovalRepository approvalRepository;
+    private final FollowRepository followRepository;
 
     // 마이페이지 - 결재서류 조회
     public JSONObject findDocuments (Long userId, Integer state, Boolean isApproved) {
@@ -64,15 +66,15 @@ public class ProfileService {
 
         for (int i = 0 ; i < documents.size() ; i++) {
             documentList.add(new DocumentDto.DocumentListResponse(documents.get(i), tagRepository.findTagNameList(documents.get(i).getId()), imageRepository.findImageUrlList(documents.get(i).getId()),
-                        approvalRepository.countApprovalByDocumentId(documents.get(i).getId()), approvalRepository.countRejectByDocumentId(documents.get(i).getId())));
+                        approvalRepository.countApproveByDocumentId(documents.get(i).getId()), approvalRepository.countRejectByDocumentId(documents.get(i).getId())));
         }
 
         profile.put("profileImage", user.getProfileImage());
         profile.put("nickname", user.getNickname());
         profile.put("level", user.getLevel());
         profile.put("promotionPoint", user.getPromotionPoint());
-        profile.put("follows", 12);
-        profile.put("followings", 5);
+        profile.put("follows", followRepository.countByToUser(user.getId()));
+        profile.put("followings", followRepository.countByFromUser(user.getId()));
 
         result.put("totalCount", documents.size());
         result.put("profile", profile);


### PR DESCRIPTION
## 📝 PR 내용
코드 충돌로 인한 빌드 실패 수정
- 불필요한 Dto 필드 제거
- Dto 필드 내 날짜포맷 DateUtil.convert() 사용하여 변경
- Dto 클래스 네이밍 변경
- 마이페이지 내 결재서류 -> follow, following 수 조회 로직 구현

## 관련 이슈
close #64 