### PR TITLE
Feature/#115 결재서류 승진포인트 적립 기능 추가, 기타 수정사항 반영

### DIFF
--- a/src/main/java/com/umc/approval/domain/approval/entity/ApprovalRepository.java
+++ b/src/main/java/com/umc/approval/domain/approval/entity/ApprovalRepository.java
@@ -22,4 +22,6 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long> {
     @Query(value = "select user_id from approval where document_id = :document_id and is_approve = :is_approve", nativeQuery = true)
     List<Long> findByDocumentIdAndIsApprove(@Param("document_id") Long documentId, @Param("is_approve") Boolean isApprove);
 
+    @Query(value = "select user_id from approval where document_id = :document_id", nativeQuery = true)
+    List<Long> findByDocumentId(@Param("document_id") Long documentId);
 }

--- a/src/main/java/com/umc/approval/domain/approval/entity/ApprovalRepository.java
+++ b/src/main/java/com/umc/approval/domain/approval/entity/ApprovalRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApprovalRepository extends JpaRepository<Approval, Long> {
@@ -17,5 +18,8 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long> {
 
     @Query(value = "select count(*) from approval where document_id = :document_id and is_approve = 0", nativeQuery = true)
     int countRejectByDocumentId(@Param("document_id") Long documentId);
+
+    @Query(value = "select user_id from approval where document_id = :document_id and is_approve = :is_approve", nativeQuery = true)
+    List<Long> findByDocumentIdAndIsApprove(@Param("document_id") Long documentId, @Param("is_approve") Boolean isApprove);
 
 }

--- a/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
+++ b/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
@@ -58,6 +58,8 @@ public class DocumentDto {
     // 결재서류 상세 조회
     @Data
     public static class GetDocumentResponse{
+        private Long documentId;
+
         // user
         private String profileImage;
         private String nickname;
@@ -90,6 +92,7 @@ public class DocumentDto {
             this.nickname = user.getNickname();
             this.level = user.getLevel();
 
+            this.documentId = document.getId();
             this.category = document.getCategory().getValue();
             this.title = document.getTitle();
             this.content = document.getContent();
@@ -121,6 +124,7 @@ public class DocumentDto {
     @Data
     public static class DocumentListResponse {
         // document
+        private Long documentId;
         private Integer category;
         private String title;
         private String content;
@@ -139,6 +143,7 @@ public class DocumentDto {
 
         // Entity -> DTO
         public DocumentListResponse(Document document, List<Tag> tagNameList, List<Image> imageList, List<Approval> approvalList) {
+            this.documentId = document.getId();
             this.category = document.getCategory().getValue();
             this.title = document.getTitle();
             this.content = document.getContent();

--- a/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
+++ b/src/main/java/com/umc/approval/domain/document/dto/DocumentDto.java
@@ -82,12 +82,15 @@ public class DocumentDto {
         private Integer likedCount;
         private Integer commentCount;
         private String datetime;
+        private boolean isModified;
         private Long view;
 
 
         // Entity -> DTO
-        public GetDocumentResponse(Document document, User user, List<String> tagNameList, List<String> imageUrlList,
-                                   Link link, int approveCount, int rejectCount, int likedCount, int commentCount) {
+        public GetDocumentResponse(Document document, User user,
+                                   List<String> tagNameList, List<String> imageUrlList,
+                                   Link link, int approveCount, int rejectCount,
+                                   int likedCount, int commentCount, boolean isModified) {
             this.profileImage = user.getProfileImage();
             this.nickname = user.getNickname();
             this.level = user.getLevel();
@@ -107,6 +110,7 @@ public class DocumentDto {
             this.likedCount = likedCount;
             this.commentCount = commentCount;
             this.datetime = DateUtil.convert(document.getCreatedAt());
+            this.isModified = isModified;
             this.view = document.getView();
         }
     }

--- a/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
@@ -18,12 +18,8 @@ public interface DocumentRepository extends JpaRepository<Document, Long>, Docum
     void updateView(@Param("document_id") Long documentId);
 
     @Modifying
-    @Query(value = "update document set state = 0 where document_id = :document_id", nativeQuery = true)
-    void updateStateApproved(@Param("document_id") Long documentId);
-
-    @Modifying
-    @Query(value = "update document set state = 1 where document_id = :document_id", nativeQuery = true)
-    void updateStateRejected(@Param("document_id") Long documentId);
+    @Query(value = "update document set state = :state where document_id = :document_id", nativeQuery = true)
+    void updateState(@Param("document_id") Long documentId, @Param("state") Integer state);
 
     @Query("select i from Document i where (i.state = 0 or i.state = 1) and i.user.id = :user_id")
     Page<Document> findByUserId(@Param("user_id") Long userId, Pageable pageable);

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -104,8 +104,11 @@ public class DocumentService {
         int likedCount = likeRepository.countByDocumentId(documentId);
         int commentCount = commentRepository.countByDocumentId(documentId);
 
+        // 게시글 수정 유무
+        boolean isModified = document.getCreatedAt().isEqual(document.getModifiedAt()) ? false : true;
+
         return new DocumentDto.GetDocumentResponse(document, user, tagNameList, imageUrlList, link,
-                approveCount, rejectCount, likedCount, commentCount);
+                approveCount, rejectCount, likedCount, commentCount, isModified);
     }
 
     public void updateDocument(Long documentId, DocumentDto.DocumentRequest request) {

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -79,6 +79,9 @@ public class DocumentService {
         }
 
         createImages(request.getImages(), document);
+
+        // 포인트 적립
+        userRepository.updatePoint(user.getId(),100L);
     }
 
     public DocumentDto.GetDocumentResponse getDocument(Long documentId) {

--- a/src/main/java/com/umc/approval/domain/report/service/ReportService.java
+++ b/src/main/java/com/umc/approval/domain/report/service/ReportService.java
@@ -2,6 +2,7 @@ package com.umc.approval.domain.report.service;
 
 import static com.umc.approval.global.exception.CustomErrorType.*;
 
+import com.umc.approval.domain.approval.entity.ApprovalRepository;
 import com.umc.approval.domain.comment.entity.Comment;
 import com.umc.approval.domain.comment.entity.CommentRepository;
 import com.umc.approval.domain.document.entity.Document;
@@ -63,6 +64,7 @@ public class ReportService {
     private final CommentRepository commentRepository;
     private final ScrapRepository scrapRepository;
     private final FollowRepository followRepository;
+    private final ApprovalRepository approvalRepository;
 
     public void createPost(ReportDto.ReportRequest request) {
 
@@ -97,6 +99,12 @@ public class ReportService {
 
         //이미지 등록
         createImages(request.getImages(), report);
+
+        // 작성자 포인트 적립
+        userRepository.updatePoint(document.getUser().getId(),500L);
+        // 결재 참여자 포인트 적립
+        List<Long> userIdList = approvalRepository.findByDocumentId(document.getId());
+        userRepository.updatePoint(userIdList, 200L);
     }
 
     // 결재서류 글 작성시 결재서류 선택 리스트

--- a/src/main/java/com/umc/approval/domain/user/entity/UserRepository.java
+++ b/src/main/java/com/umc/approval/domain/user/entity/UserRepository.java
@@ -1,7 +1,9 @@
 package com.umc.approval.domain.user.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findBySocialId(Long socialId);
 
     List<User> findByNicknameContains(String query);
+
+    @Modifying
+    @Query(value = "update users set promotion_point = promotion_point + :point where user_id = :user_id", nativeQuery = true)
+    void updatePoint(@Param("user_id") Long userId, @Param("point") Long point);
+
+    @Modifying
+    @Query(value = "update users set promotion_point = promotion_point + :point where user_id in (:user_id_list)", nativeQuery = true)
+    void updatePoint(@Param("user_id_list") List<Long> userIdList, @Param("point")Long point);
 }


### PR DESCRIPTION
## 📝 PR 내용
- 결재서류와 관련된 승진포인트 적립 기능 추가
- 결재보고서와 관련된 승진포인트 적립 기능 추가
- 결재서류 상세조회, 목록조회 시 documentId response에 추가
- 결재서류 상세조회 시 게시글 수정 유무 알 수 있는 상태 값 response에 추가

## 관련 이슈
close #115