### PR TITLE
[FEAT #153] 관심부서 설정/조회 기능 구현

### DIFF
--- a/src/main/java/com/umc/approval/domain/like_category/controller/LikeCategoryController.java
+++ b/src/main/java/com/umc/approval/domain/like_category/controller/LikeCategoryController.java
@@ -1,0 +1,31 @@
+package com.umc.approval.domain.like_category.controller;
+
+import com.umc.approval.domain.like_category.dto.LikeCategoryDto;
+import com.umc.approval.domain.like_category.service.LikeCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequestMapping("/documents/likedCategory")
+@RequiredArgsConstructor
+@RestController
+public class LikeCategoryController {
+    private final LikeCategoryService likeCategoryService;
+
+    @GetMapping("/my")
+    public ResponseEntity<LikeCategoryDto.Response> getLikeCategoryList(
+            HttpServletRequest request
+    ) {
+        return ResponseEntity.ok(likeCategoryService.getLikeCategoryList(request));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> likeCategory(
+            @RequestBody LikeCategoryDto.Request likeCategoryRequest
+    ) {
+        likeCategoryService.likeCategory(likeCategoryRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/umc/approval/domain/like_category/dto/LikeCategoryDto.java
+++ b/src/main/java/com/umc/approval/domain/like_category/dto/LikeCategoryDto.java
@@ -1,0 +1,22 @@
+package com.umc.approval.domain.like_category.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class LikeCategoryDto {
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor
+    public static class Request {
+        private List<Integer> likedCategory;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private Boolean isSet;
+        private List<Integer> likedCategory;
+    }
+}

--- a/src/main/java/com/umc/approval/domain/like_category/entity/LikeCategoryRepository.java
+++ b/src/main/java/com/umc/approval/domain/like_category/entity/LikeCategoryRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LikeCategoryRepository extends JpaRepository<LikeCategory, Long> {
 
     @Query("select l from LikeCategory l " +
             "where l.user.id = :userId")
     List<LikeCategory> findByUserId(@Param("userId") Long userId);
+
+    Void deleteByCategoryAndUserId(CategoryType categoryType, Long userId);
 }

--- a/src/main/java/com/umc/approval/domain/like_category/service/LikeCategoryService.java
+++ b/src/main/java/com/umc/approval/domain/like_category/service/LikeCategoryService.java
@@ -1,16 +1,99 @@
 package com.umc.approval.domain.like_category.service;
 
+import com.umc.approval.domain.like.dto.LikeDto;
+import com.umc.approval.domain.like.entity.Like;
+import com.umc.approval.domain.like_category.dto.LikeCategoryDto;
+import com.umc.approval.domain.like_category.entity.LikeCategory;
 import com.umc.approval.domain.like_category.entity.LikeCategoryRepository;
+import com.umc.approval.domain.user.entity.User;
+import com.umc.approval.domain.user.entity.UserRepository;
+import com.umc.approval.global.exception.CustomErrorType;
+import com.umc.approval.global.exception.CustomException;
+import com.umc.approval.global.security.service.JwtService;
 import com.umc.approval.global.type.CategoryType;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.transaction.Transactional;
+
+
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class LikeCategoryService {
 
     private final LikeCategoryRepository likeCategoryRepository;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
 
+    public LikeCategoryDto.Response getLikeCategoryList(HttpServletRequest request) {
+        User user = userRepository.findById(jwtService.getId())
+                .orElseThrow(() -> new CustomException(CustomErrorType.USER_NOT_FOUND));
+
+        List<Integer> currentLikeCategoryList = likeCategoryRepository.findByUserId(user.getId())
+                .stream().map(l -> l.getCategory().getValue()).collect(Collectors.toList());
+
+        if (currentLikeCategoryList.isEmpty()) {
+            return new LikeCategoryDto.Response(false,null);
+        }
+
+        return new LikeCategoryDto.Response(true, currentLikeCategoryList);
+    }
+
+    public void likeCategory(LikeCategoryDto.Request likeCategoryRequest) {
+        User user = userRepository.findById(jwtService.getId())
+                .orElseThrow(() -> new CustomException(CustomErrorType.USER_NOT_FOUND));
+
+        // 기존 DB에 저장되어있던 카테고리 리스트 받아오기
+        List<LikeCategory> currentLikeCategoryList = likeCategoryRepository.findByUserId(user.getId());
+
+        if(currentLikeCategoryList.isEmpty())
+        {
+            createLikeCategory(likeCategoryRequest.getLikedCategory(), user);
+        }
+        else {
+            List<Integer> current = currentLikeCategoryList.stream().map(l -> l.getCategory().getValue()).collect(Collectors.toList());
+            List<Integer> post = likeCategoryRequest.getLikedCategory();
+
+            List<Integer> delete = current.stream().filter(c -> !post.contains(c)).collect(Collectors.toList());
+            List<Integer> add = post.stream().filter(p -> !current.contains(p)).collect(Collectors.toList());
+
+            deleteLikeCategory(delete, user);
+            createLikeCategory(add, user);
+        }
+    }
+
+   private void createLikeCategory (List<Integer> likeCategories, User user) {
+        if(likeCategories != null) {
+            for (Integer likeCategory : likeCategories) {
+                LikeCategory newLikeCategory = LikeCategory.builder()
+                        .user(user)
+                        .category(findCategory(likeCategory))
+                        .seq(0)
+                        .build();
+                likeCategoryRepository.save(newLikeCategory);
+            }
+        }
+   }
+
+    private void deleteLikeCategory (List<Integer> likeCategories, User user) {
+        if(likeCategories != null) {
+            for (Integer likeCategory : likeCategories) {
+                likeCategoryRepository.deleteByCategoryAndUserId(findCategory(likeCategory), user.getId());
+            }
+        }
+    }
+
+    private CategoryType findCategory(Integer category) {
+        return Arrays.stream(CategoryType.values())
+                .filter(c -> c.getValue() == category)
+                .findAny().get();
+    }
 
 }

--- a/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/umc/approval/global/security/filter/CustomAuthorizationFilter.java
@@ -62,6 +62,8 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
                         || (pathMatcher.match("/scrap/**", path) && request.getMethod().equals("POST"))
                         || (pathMatcher.match("/follow/**", path) && request.getMethod().equals("POST"))
                         || (pathMatcher.match("/accuse/**", path) && request.getMethod().equals("POST"))
+                        || (pathMatcher.match("/documents/likedCategory/**", path) && request.getMethod().equals("POST"))
+                        || (pathMatcher.match("/documents/likedCategory/**", path) && request.getMethod().equals("GET"))
                         || pathMatcher.match("/auth/token/check", path)
         );
     }


### PR DESCRIPTION
## 📝 PR 내용
순서는 고정으로 안드와 협의 후 기능 변경
관심부서 설정/ 조회 기능 구현 
POST 요청된 관심부서 리스트 값들과 기존 DB에 저장된 값들을 비교하여 추가, 삭제하도록 구현

## 관련 이슈
close #153 