### PR TITLE
[FIX #177] 결재서류 게시글 삭제 기능 수정

### DIFF
--- a/src/main/java/com/umc/approval/domain/accuse/entity/AccuseRepository.java
+++ b/src/main/java/com/umc/approval/domain/accuse/entity/AccuseRepository.java
@@ -2,6 +2,8 @@ package com.umc.approval.domain.accuse.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AccuseRepository extends JpaRepository<Accuse, Long>, AccuseRepositoryCustom {
+import java.util.List;
 
+public interface AccuseRepository extends JpaRepository<Accuse, Long>, AccuseRepositoryCustom {
+    List<Accuse> findByDocumentId(Long documentId);
 }

--- a/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
+++ b/src/main/java/com/umc/approval/domain/document/service/DocumentService.java
@@ -1,5 +1,7 @@
 package com.umc.approval.domain.document.service;
 
+import com.umc.approval.domain.accuse.entity.Accuse;
+import com.umc.approval.domain.accuse.entity.AccuseRepository;
 import com.umc.approval.domain.approval.entity.Approval;
 import com.umc.approval.domain.approval.entity.ApprovalRepository;
 import com.umc.approval.domain.comment.entity.Comment;
@@ -17,6 +19,7 @@ import com.umc.approval.domain.link.entity.Link;
 import com.umc.approval.domain.link.entity.LinkRepository;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.report.entity.ReportRepository;
+import com.umc.approval.domain.report.service.ReportService;
 import com.umc.approval.domain.scrap.entity.Scrap;
 import com.umc.approval.domain.scrap.entity.ScrapRepository;
 import com.umc.approval.domain.tag.entity.Tag;
@@ -57,6 +60,8 @@ public class DocumentService {
     private final LikeCategoryRepository likeCategoryRepository;
     private final ScrapRepository scrapRepository;
     private final ReportRepository reportRepository;
+    private final ReportService reportService;
+    private final AccuseRepository accuseRepository;
 
     public void createDocument(DocumentDto.DocumentRequest request) {
         User user = certifyUser();
@@ -232,11 +237,17 @@ public class DocumentService {
         // 승인/반려 삭제
         List<Approval> approvalList = approvalRepository.findByDocumentId(documentId);
         if(approvalList != null){
-            approvalRepository.deleteAllInBatch(approvalList);
+            approvalRepository.deleteAll(approvalList);
         }
 
-        // 결재보고서 삭제
-        reportRepository.findByDocumentId(documentId).ifPresent(reportRepository::delete);
+        // 결재보고서 및 관련 내용 모두 삭제
+        reportRepository.findByDocumentId(documentId).ifPresent(r -> reportService.deletePost(r.getId()));
+
+        // 신고 내역 삭제
+        List<Accuse> accuseList = accuseRepository.findByDocumentId(documentId);
+        if(accuseList != null){
+            accuseRepository.deleteAll(accuseList);
+        }
 
         // document 삭제
         documentRepository.deleteById(documentId);


### PR DESCRIPTION
## 📝 PR 내용
결재서류 게시글 삭제 로직 수정
 - 신고 내역 삭제
 - 결재보고서와 연관된 내용 모두 삭제

## 관련 이슈
close #177