### PR TITLE
[FEAT #179] 결재톡톡, 결재보고서 삭제 기능 수정

### DIFF
--- a/src/main/java/com/umc/approval/domain/accuse/entity/AccuseRepository.java
+++ b/src/main/java/com/umc/approval/domain/accuse/entity/AccuseRepository.java
@@ -1,7 +1,9 @@
 package com.umc.approval.domain.accuse.entity;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccuseRepository extends JpaRepository<Accuse, Long>, AccuseRepositoryCustom {
-
+    List<Accuse> findByReportId(Long reportId);
+    List<Accuse> findByToktokId(Long toktokId);
 }

--- a/src/main/java/com/umc/approval/domain/report/dto/ReportDto.java
+++ b/src/main/java/com/umc/approval/domain/report/dto/ReportDto.java
@@ -36,6 +36,15 @@ public class ReportDto {
         private List<String> tag;
 
         private List<String> images;
+
+        public Report toEntity(Document document) {
+            return Report.builder()
+                .content(content)
+                .document(document)
+                .notification(true)
+                .view(0L)
+                .build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/umc/approval/domain/toktok/dto/ToktokDto.java
+++ b/src/main/java/com/umc/approval/domain/toktok/dto/ToktokDto.java
@@ -1,32 +1,21 @@
 package com.umc.approval.domain.toktok.dto;
-import com.umc.approval.domain.link.entity.Link;
 import com.umc.approval.domain.tag.entity.Tag;
 import com.umc.approval.domain.toktok.entity.Toktok;
 import com.umc.approval.domain.user.entity.User;
 import com.umc.approval.domain.vote.entity.Vote;
+import com.umc.approval.global.type.CategoryType;
 import com.umc.approval.global.util.DateUtil;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import com.umc.approval.domain.image.entity.Image;
 import com.umc.approval.domain.link.dto.LinkDto;
-import com.umc.approval.domain.tag.entity.Tag;
-import com.umc.approval.domain.toktok.entity.Toktok;
-import com.umc.approval.domain.vote.entity.Vote;
 import com.umc.approval.domain.vote.entity.VoteOption;
-import com.umc.approval.global.util.DateUtil;
 import lombok.*;
-
-import javax.validation.constraints.*;
-import java.util.List;
-import java.util.stream.Collectors;
-
 
 public class ToktokDto {
 
@@ -59,6 +48,17 @@ public class ToktokDto {
         private List<String> tag;
 
         private List<String> images;
+
+        public Toktok toEntity(User user, CategoryType categoryType, Vote vote) {
+            return Toktok.builder()
+                .user(user)
+                .content(content)
+                .category(categoryType)
+                .vote(vote)
+                .view(0L)
+                .notification(true)
+                .build();
+        }
     }
 
     //게시글 상세 조회


### PR DESCRIPTION
## 📝 PR 내용
결재톡톡, 결재보고서 삭제 시 신고 내역도 삭제하도록 수정

## 관련 이슈
close #179 