### PR TITLE
[FIX #187] 마이페이지에서 조회되는 게시글 목록 최신순으로 정렬되도록 수정

### DIFF
--- a/src/main/java/com/umc/approval/domain/comment/entity/CommentRepository.java
+++ b/src/main/java/com/umc/approval/domain/comment/entity/CommentRepository.java
@@ -41,15 +41,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     List<Comment> findByDocumentId(Long documentId);
 
-    @Query("select d from Document d where d.id IN (select c.document.id from Comment c where c.user.id = :userId)")
+    @Query("select distinct d from Document d join Comment c on c.document.id = d.id order by c.createdAt desc")
     List<Document> findDocuments(Long userId);
 
-    @Query("select d from Document d where d.id IN (select c.document.id from Comment c where c.user.id = :userId) AND d.state = :state")
-    List<Document> findDocumentsByState(Long userId, Integer state);
+    @Query("select c from Comment c join fetch c.document d where c.user.id = :userId and d.state = :state order by c.createdAt desc")
+    List<Comment> findCommentsByUserAndState(Long userId, Integer state);
 
-    @Query("select t from Toktok t where t.id IN (select c.toktok.id from Comment c where c.user.id = :userId)")
+    @Query("select distinct t from Toktok t join Comment c on c.toktok.id = t.id order by c.createdAt desc")
     List<Toktok> findToktoks(Long userId);
 
-    @Query("select r from Report r where r.id IN (select c.report.id from Comment c where c.user.id = :userId)")
+    @Query("select distinct r from Report r join Comment c on c.report.id = r.id order by c.createdAt desc")
     List<Report> findReports(Long userId);
 }

--- a/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
+++ b/src/main/java/com/umc/approval/domain/document/entity/DocumentRepository.java
@@ -21,7 +21,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long>, Docum
     @Query(value = "update document set state = :state where document_id = :document_id", nativeQuery = true)
     void updateState(@Param("document_id") Long documentId, @Param("state") Integer state);
 
-    @Query("select i from Document i where (i.state = 0 or i.state = 1) and i.user.id = :user_id")
+    @Query("select i from Document i where (i.state = 0 or i.state = 1) and i.user.id = :user_id order by i.createdAt desc")
     List<Document> findByUserId(@Param("user_id") Long userId);
     
     @Query("select d from Document d " +
@@ -30,13 +30,20 @@ public interface DocumentRepository extends JpaRepository<Document, Long>, Docum
     Optional<Document> findByIdWithUser(@Param("documentId") Long documentId);
 
     // 마이페이지 - 사원증 조회
-    @Query(value = "select d from Document d where d.user.id = :userId")
+    @Query(value = "select d from Document d " +
+            "where d.user.id = :userId " +
+            "order by d.createdAt desc")
     List<Document> findAllByUserId(@Param("userId") Long userId); // 사용자가 작성한 결재서류 전체 조회
 
-    @Query(value = "select d from Document d where d.user.id = :userId AND d.state = :state")
+    @Query(value = "select d from Document d " +
+            "where d.user.id = :userId " +
+            "AND d.state = :state " +
+            "order by d.createdAt desc")
     List<Document> findAllByState(@Param("userId") Long userId, @Param("state") Integer state); // 사용자가 작성한 결재서류 상태별 조회
 
-    @Query(value = "select d from Document d where d.id IN (select a.document.id from Approval a where a.isApprove = :isApproved AND a.user.id = :userId)")
+    @Query(value = "select d from Document d " +
+            "where d.id IN (select a.document.id from Approval a where a.isApprove = :isApproved AND a.user.id = :userId) " +
+            "order by d.createdAt desc")
     List<Document> findAllByApproval(@Param("userId") Long userId, @Param("isApproved") Boolean isApproved); // 사용자가 결재한 결재서류 승인별 조회
 
     // 게시글 목록 조회(페이징 x)
@@ -56,7 +63,13 @@ public interface DocumentRepository extends JpaRepository<Document, Long>, Docum
             "order by d.createdAt desc")
     List<Document> findAllByLikedCategory(@Param("categories") List<CategoryType> categories);
 
-    @Query("select distinct d from Document d left join fetch d.approvals a join fetch a.user u where d.state = :state and a.isApprove = :isApproved and u.id = :userId")
+    @Query("select distinct d from Document d " +
+            "left join fetch d.approvals a " +
+            "join fetch a.user u " +
+            "where d.state = :state " +
+            "and a.isApprove = :isApproved " +
+            "and u.id = :userId " +
+            "order by d.createdAt desc")
     List<Document> findAllByStateApproval(@Param("userId") Long userId,
                                           @Param("state") Integer state, @Param("isApproved") Boolean isApproved); // 사용자가 결재한 결재서류 상태별 & 승인별 조회
 

--- a/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
@@ -14,6 +14,7 @@ import com.umc.approval.domain.profile.dto.ProfileDto;
 import com.umc.approval.domain.report.dto.ReportDto;
 import com.umc.approval.domain.report.entity.Report;
 import com.umc.approval.domain.report.entity.ReportRepository;
+import com.umc.approval.domain.scrap.entity.Scrap;
 import com.umc.approval.domain.scrap.entity.ScrapRepository;
 import com.umc.approval.domain.toktok.dto.ToktokDto;
 import com.umc.approval.domain.toktok.entity.Toktok;
@@ -195,7 +196,8 @@ public class ProfileService {
                 if (state < 0 || state > 2) {
                     throw new CustomException(PARAM_INVALID_VALUE);
                 } else {
-                    documents = scrapRepository.findDocumentsByState(user.getId(), state);
+                    documents = scrapRepository.findScrapsByUserAndState(user.getId(), state)
+                            .stream().map(Scrap::getDocument).collect(Collectors.toList());
                 }
 
             } else { // 전체 조회

--- a/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/umc/approval/domain/profile/service/ProfileService.java
@@ -1,5 +1,6 @@
 package com.umc.approval.domain.profile.service;
 
+import com.umc.approval.domain.comment.entity.Comment;
 import com.umc.approval.domain.comment.entity.CommentRepository;
 import com.umc.approval.domain.document.dto.DocumentDto;
 import com.umc.approval.domain.document.entity.Document;
@@ -149,7 +150,8 @@ public class ProfileService {
                 if (state < 0 || state > 2) {
                     throw new CustomException(PARAM_INVALID_VALUE);
                 } else {
-                    documents = commentRepository.findDocumentsByState(user.getId(), state);
+                    documents = commentRepository.findCommentsByUserAndState(user.getId(), state)
+                            .stream().map(Comment::getDocument).collect(Collectors.toList());
                 }
 
             } else { // 전체 조회

--- a/src/main/java/com/umc/approval/domain/scrap/entity/ScrapRepository.java
+++ b/src/main/java/com/umc/approval/domain/scrap/entity/ScrapRepository.java
@@ -6,7 +6,6 @@ import com.umc.approval.domain.toktok.entity.Toktok;
 import com.umc.approval.domain.user.entity.User;
 import java.util.List;
 
-import com.umc.approval.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -29,15 +28,15 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long>, ScrapReposi
 
     Long countByUserAndReport(User user, Report report);
 
-    @Query("select d from Document d where d.id IN (select s.document.id from Scrap s where s.user.id = :userId)")
+    @Query("select distinct d from Document d join Scrap s on s.document.id = d.id order by s.createdAt desc")
     List<Document> findDocuments(Long userId);
 
-    @Query("select d from Document d where d.id IN (select s.document.id from Scrap s where s.user.id = :userId) AND d.state = :state")
-    List<Document> findDocumentsByState(Long userId, Integer state);
+    @Query("select s from Scrap s join fetch s.document d where s.user.id = :userId and d.state = :state order by s.createdAt desc")
+    List<Scrap> findScrapsByUserAndState(Long userId, Integer state);
 
-    @Query("select t from Toktok t where t.id IN (select s.toktok.id from Scrap s where s.user.id = :userId)")
+    @Query("select distinct t from Toktok t join Scrap s on s.toktok.id = t.id order by s.createdAt desc")
     List<Toktok> findToktoks(Long userId);
 
-    @Query("select r from Report r where r.id IN (select s.report.id from Scrap s where s.user.id = :userId)")
+    @Query("select distinct r from Report r join Scrap s on s.report.id = r.id order by s.createdAt desc")
     List<Report> findReports(Long userId);
 }

--- a/src/main/java/com/umc/approval/domain/toktok/entity/ToktokRepository.java
+++ b/src/main/java/com/umc/approval/domain/toktok/entity/ToktokRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ToktokRepository extends JpaRepository<Toktok, Long>, ToktokRepositoryCustom {
-    @Query("select t from Toktok t where t.user.id = :userId")
+    @Query("select t from Toktok t where t.user.id = :userId order by t.createdAt desc")
     List<Toktok> findByUserId(@Param("userId") Long userId);
 
     @Query("select t from Toktok t " +


### PR DESCRIPTION
## 📝 PR 내용
- 결재서류 최신순 정렬
- 결재톡톡 최신순 정렬
- 결재보고서 최신순 정렬
- 스크랩한 게시글 스크랩한 순서대로 정렬
- 댓글 단 글 댓글 단 순서대로 정렬

## 관련 이슈
close #187 